### PR TITLE
Rewritten the "How to get your user token" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
                         <li>Open the Discord desktop app or login on the Discord website <a href="https://discordapp.com/login" target="_blank">here</a></li>
                         <li>Open the Chrome Dev Tools with the keyboard shortcut <pre>Ctrl + Shift + I</pre></li>
                         <li>Go to the Application tab</li>
-                        <li>Go to Storage -> Local Storage -> discordapp.com</li>
+                        <li>Go to Network -> Science -> Request Headers -> Authorization</li>
                         <li>Find the token row and copy it (make sure you remove the quotes)</li>
                     </ul>
                 </p>


### PR DESCRIPTION
Rewritten it as there isn't any token field in the localstorage. Instead rewrote it so the user uses the request header
"Network -> Science -> Request Headers -> Authorization"