### PR TITLE
Fix old token snippit no longer working

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
                         <li>
                             Paste and execute the following snippet:
                             <p>
-                                <code style="user-select: all;">(webpackChunkdiscord_app.push([[''],{},e=&gt;{m=[];for(let c in e.c)m.push(e.c[c])}]),m).find(m=&gt;m?.exports?.default?.getToken!==void 0).exports.default.getToken()</code>
+                                <code style="user-select: all;">(()=>{let t;window.webpackChunkdiscord_app.push([[Math.random()],{},r=>{for(const i in r.c){const m=r.c[i],f=m?.exports?.default?.getToken??m?.exports?.getToken;if(typeof f=="function"){t=f();return}}}]);t?console.log(`"${t}"`):console.warn("Token not found.");})();</code>
                             </p>
                         </li>
                         <li>Your token will be returned at the bottom of the console. Copy the contents between "". This is your user token.</li>


### PR DESCRIPTION
Old JS for retrieving the user token broke recently, this is a new slightly more robust version

A Beautified breakdown is as follows
```js
(() => {
    // Declare token variable in outer scope
    let t;

    // Push a chunk so Webpack will invoke our callback immediately
    window.webpackChunkdiscord_app.push([
        [Math.random()], // unique chunk id
        {}, // no extra modules
        r => {
            // Scan every module in the cache
            for (const i in r.c) {
                const m = r.c[i];
                // Try both shapes: default.getToken or direct getToken
                const f = m?.exports?.default?.getToken ??
                    m?.exports?.getToken;

                if (typeof f === 'function') {
                    t = f();
                    return; // stop after the first hit
                }
            }
        }
    ]);

    // Log the token if found, else warn
    if (t) {
        console.log(`"${t}"`);
    } else {
        console.warn("Token not found.");
    }
})();
```